### PR TITLE
redirect to correct index URL

### DIFF
--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -3,7 +3,7 @@ import json
 import os
 import subprocess
 from queue import Queue
-from bottle import route, run, Bottle, request, static_file
+from bottle import route, run, Bottle, request, static_file, redirect
 from threading import Thread
 import youtube_dl
 from pathlib import Path
@@ -27,6 +27,12 @@ app_defaults = {
 @app.route('/youtube-dl')
 def dl_queue_list():
     return static_file('index.html', root='./')
+
+
+@app.route('/youtube-dl/')
+@app.route('/')
+def redirectToCorrectIndexURL():
+    redirect("/youtube-dl")
 
 
 @app.route('/youtube-dl/static/:filename#.*#')


### PR DESCRIPTION
If users navigate to slightly wrong index URL, redirect them to the right path. In my opinion this meets user expectations better than insisting on correctness.
Supported paths: / and youtube-dl/